### PR TITLE
Feature/podaac 5326: add granule names to harmony download call

### DIFF
--- a/server/client/harmony.js
+++ b/server/client/harmony.js
@@ -28,6 +28,7 @@ async function subset(job, accessToken) {
     url += `&subset=lat(${south}:${north})`;
     url += `&subset=lon(${west}:${east})`;
     //url += `&subset=time("${startDate}":"${endDate}")`;
+    // add granule names
     granuleNames.forEach((granuleName) => {
         url += `&granuleName=${granuleName}`;
     });

--- a/server/client/harmony.js
+++ b/server/client/harmony.js
@@ -10,6 +10,7 @@ async function subset(job, accessToken) {
         searchStartDate,
         searchEndDate,
         granuleIds = [],
+        granuleNames = [],
         variables,
         merge
     } = job.subjobs[0];
@@ -27,6 +28,9 @@ async function subset(job, accessToken) {
     url += `&subset=lat(${south}:${north})`;
     url += `&subset=lon(${west}:${east})`;
     //url += `&subset=time("${startDate}":"${endDate}")`;
+    granuleNames.forEach((granuleName) => {
+        url += `&granuleName=${granuleName}`;
+    });
     granuleIds.forEach((granuleId) => {
         url += `&granuleId=${granuleId}`;
     });


### PR DESCRIPTION
Changes:
- Added granule names as parameters in url if present

Tested:
- tested and working locally and in SIT