### PR TITLE
Issue/hitide profile 45 - fix history not showing up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - issue-58: Changed harmony submit call from GET to POST.
 ### Removed
 ### Fixed
+- issue-45: Fixed history not showing up.
 
 
 ## [4.10.0]

--- a/server/util/history-db.js
+++ b/server/util/history-db.js
@@ -91,7 +91,15 @@ function convertDbJobToJsJob(dbJob) {
         }
 
         if(jsonProperties[jsKey]) {
-            value = JSON.parse(value);
+            // if string is not valid json, convert it to valid json.
+            try {
+                value = JSON.parse(value);
+            } catch(error) {
+                if(dbKey === 'download_urls') {
+                    value = ['https://harmony.earthdata.nasa.gov/jobs/' + dbJob['token']]
+                }
+            }
+            
         }
 
         jsJob[jsKey] = value;


### PR DESCRIPTION
### Changes

- When history was being retrieved, the download links value was more about 65kb and the max allowed size for the value int the database was 32kb. This meant that it was cutting off the download links and a parse error was being thrown for converting the cut off value to JSON.
- The fix was to return a download link directly to harmony that lists all of the jobs on their site.