### PR TITLE
issue/hitide-profile-72: add form data content type to harmony call

### DIFF
--- a/server/client/harmony.js
+++ b/server/client/harmony.js
@@ -38,6 +38,7 @@ async function subset(job, accessToken) {
             method: 'POST',
             headers: {
                 Authorization: `Bearer ${accessToken}`,
+                ContentType: 'multipart/form-data',
             },
             body: formData
         });


### PR DESCRIPTION
### Changes

- added the content type of **multipart/form-data** to the harmony submit call. The error before was that downloads with 100 or more granules would not work. This content type specification fixed the bug.